### PR TITLE
updated in a pythonic manner the parts 5.2 and 6.2

### DIFF
--- a/FaceDetection.ipynb
+++ b/FaceDetection.ipynb
@@ -634,6 +634,41 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### -> An alternative manner to do so :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images = list()\n",
+    "\n",
+    "for folder in ['train', 'test', 'val']:\n",
+    "    specific_images = tf.data.Dataset.list_files(f'aug_data\\\\{folder}\\\\images\\\\*.jpg', shuffle=False)\n",
+    "    specific_images = specific_images.map(load_image)\n",
+    "    specific_images = specific_images.map(lambda x: tf.image.resize(x, (120,120)))\n",
+    "    specific_images = specific_images.map(lambda x: x/255)\n",
+    "    images.append(specific_images)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_images = images[0]\n",
+    "test_images = images[1]\n",
+    "val_images = images[2]"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -714,6 +749,39 @@
    "source": [
     "val_labels = tf.data.Dataset.list_files('aug_data\\\\val\\\\labels\\\\*.json', shuffle=False)\n",
     "val_labels = val_labels.map(lambda x: tf.py_function(load_labels, [x], [tf.uint8, tf.float16]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### -> An alternative manner to do so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels = list()\n",
+    "\n",
+    "for folder in ['train', 'test', 'val']:\n",
+    "    specific_labels = tf.data.Dataset.list_files(f'aug_data\\\\{folder}\\\\labels\\\\*.json', shuffle=False)\n",
+    "    # loading the labels\n",
+    "    specific_labels = specific_labels.map(lambda x: tf.py_function(load_labels, [x], [tf.uint8, tf.float16 ]))\n",
+    "    labels.append(specific_labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_labels = labels[0]\n",
+    "test_labels = labels[1]\n",
+    "val_labels = labels[2]"
    ]
   },
   {


### PR DESCRIPTION
### Problem: <br>
Looking at sections 5.2 and 6.2, they seemed to have a repetitive code that could be handled in a more condensed manner

### Solution: <br>
The solution is to use loops around the ```aug_data``` folders (i.e: train, test, val) and add the images (resp labels) into a dedicated list. At the end, we will just retrieve the content of the list and store it in the dedicated variables.